### PR TITLE
Removed date and time conversion

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -343,14 +343,14 @@ function wrapInQuotes (val) {
 }
 */
 function toSqlDate (date) {
-  date = date.getUTCFullYear() + '-' +
-    ('00' + (date.getUTCMonth() + 1)).slice(-2) + '-' +
-    ('00' + date.getUTCDate()).slice(-2) + ' ' +
-    ('00' + date.getUTCHours()).slice(-2) + ':' +
-    ('00' + date.getUTCMinutes()).slice(-2) + ':' +
-    ('00' + date.getUTCSeconds()).slice(-2)
+  date = date.getFullYear() + '-' +
+	('00' + (date.getMonth()+1)).slice(-2) + '-' +
+	('00' + date.getDate()).slice(-2) + ' ' +
+	('00' + date.getHours()).slice(-2) + ':' +
+	('00' + date.getMinutes()).slice(-2) + ':' +
+	('00' + date.getSeconds()).slice(-2);
 
-  return date
+  return date;
 }
 
 function validSubAttrCriteria (c) {


### PR DESCRIPTION
I faced some issues with date/time conversions and time zones so I did the same as @particlebanana did for the [sails-mysql](https://github.com/balderdashy/sails-mysql) adapter in this commit : https://github.com/balderdashy/sails-mysql/commit/1a2178e81482f3cc8de60c0e6d29b9feceab0864